### PR TITLE
bump test dependency to role-docker==1.1.0, too

### DIFF
--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -1,4 +1,4 @@
 - name: blunix.role-docker
   src: https://github.com/blunix/role-docker.git
   scm: git
-  version: 7be1e7c46da08080ed3fdcfbbd9002508c8357bc
+  version: 1.1.0


### PR DESCRIPTION
This PR fixes the missing dep bump in the Molecule tests.