### PR TITLE
Feature cron

### DIFF
--- a/templates/etc/cron.d/easydb5
+++ b/templates/etc/cron.d/easydb5
@@ -2,7 +2,7 @@
 
 # m h dom m dow user command
 
-{% if easydb_cron_update_weekday|length %}
+{% if easydb_cron_update_weekday is defined and easydb_cron_update_weekday|length %}
 {{ easydb_cron_update_minute }} {{ easydb_cron_update_hour }} * * {{ easydb_cron_update_weekday }} root {{ easydb_cron_update_script }}
 {% endif %}
 {{ easydb_cron_backup_minute }} {{ easydb_cron_backup_hour }} * * {{ easydb_cron_backup_weekday }} root {{ easydb_cron_backup_script }}

--- a/templates/etc/cron.d/easydb5
+++ b/templates/etc/cron.d/easydb5
@@ -2,7 +2,7 @@
 
 # m h dom m dow user command
 
-{% if easydb_cron_update_weekday is defined and easydb_cron_update_weekday|length %}
+{% if easydb_cron_update_weekday is not none and easydb_cron_update_weekday|length %}
 {{ easydb_cron_update_minute }} {{ easydb_cron_update_hour }} * * {{ easydb_cron_update_weekday }} root {{ easydb_cron_update_script }}
 {% endif %}
 {{ easydb_cron_backup_minute }} {{ easydb_cron_backup_hour }} * * {{ easydb_cron_backup_weekday }} root {{ easydb_cron_backup_script }}

--- a/templates/etc/cron.d/easydb5
+++ b/templates/etc/cron.d/easydb5
@@ -2,5 +2,7 @@
 
 # m h dom m dow user command
 
+{% if easydb_cron_update_weekday|length %}
 {{ easydb_cron_update_minute }} {{ easydb_cron_update_hour }} * * {{ easydb_cron_update_weekday }} root {{ easydb_cron_update_script }}
+{% endif %}
 {{ easydb_cron_backup_minute }} {{ easydb_cron_backup_hour }} * * {{ easydb_cron_backup_weekday }} root {{ easydb_cron_backup_script }}

--- a/templates/etc/cron.d/easydb5
+++ b/templates/etc/cron.d/easydb5
@@ -2,7 +2,7 @@
 
 # m h dom m dow user command
 
-{% if easydb_cron_update_weekday is not none and easydb_cron_update_weekday|length %}
+{% if easydb_cron_update_weekday is not none and easydb_cron_update_weekday|string()|length %}
 {{ easydb_cron_update_minute }} {{ easydb_cron_update_hour }} * * {{ easydb_cron_update_weekday }} root {{ easydb_cron_update_script }}
 {% endif %}
 {{ easydb_cron_backup_minute }} {{ easydb_cron_backup_hour }} * * {{ easydb_cron_backup_weekday }} root {{ easydb_cron_backup_script }}


### PR DESCRIPTION
Hi Brian, mein erster pull-request ;-)

Im branch feature-cron ist nun endlich umgesetzt dass easydb-updates per cron auch NICHT geschaltet sein können. 
(wenn 
easydb_cron_update_weekday:
 oder 
easydb_cron_update_weekday: ''
)