### PR TITLE
use easydb_server_database in easydb_dump_dbs

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -182,7 +182,7 @@ easydb_objectstore_instance_id: prod
 
 # PostgrSQL
 # Space-separated list of db-names to dump with the script:
-easydb_dump_dbs: "eas easydb"
+easydb_dump_dbs: "{{ easydb_eas_database }} {{ easydb_server_database }}"
 # Of eas DB in $DBS keep this many newest dumps:
 easydb_dump_keep: 7
 
@@ -205,6 +205,7 @@ easydb_eas_num_workers: 1
 easydb_eas_num_soffice: 2
 easydb_eas_num_services: 5
 easydb_eas_trusted_net: "172.16.0.0/12"   # Source IP from connects from EasyDB server must be included.
+easydb_eas_database: eas
 
 # SSO
 easydb_ldap_config: ''


### PR DESCRIPTION
on some recent installations, dump is trying to dump the wrong database name and fails

https://tickets.programmfabrik.de/ticket/52786
