### PR TITLE
add option to only compare configured and actual db dumps

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -182,7 +182,7 @@ easydb_objectstore_instance_id: prod
 
 # PostgrSQL
 # Space-separated list of db-names to dump with the script:
-easydb_dump_dbs: "eas easydb"
+easydb_dump_dbs: "{{ easydb_eas_database }} {{ easydb_server_database }}"
 # Of eas DB in $DBS keep this many newest dumps:
 easydb_dump_keep: 7
 
@@ -205,6 +205,7 @@ easydb_eas_num_workers: 1
 easydb_eas_num_soffice: 2
 easydb_eas_num_services: 5
 easydb_eas_trusted_net: "172.16.0.0/12"   # Source IP from connects from EasyDB server must be included.
+easydb_eas_database: eas
 
 # SSO
 easydb_ldap_config: ''

--- a/tasks/debug/check_dump.yml
+++ b/tasks/debug/check_dump.yml
@@ -1,0 +1,16 @@
+- command: ls -1 {{ easydb_pgsql_volume_backup }}
+  register: dumps
+- debug:
+    msg: "{{ dumps.stdout_lines|join('\n') }}"
+
+- debug:
+    var: easydb_dump_dbs
+
+- command: grep '^DBS=' {{ easydb_basedir }}/maintain
+  name: grep '^DBS=' {{ easydb_basedir }}/maintain
+  register: DBS
+- name: result of grep
+  debug:
+    var: DBS.stdout_lines
+
+- meta: end_play

--- a/tasks/debug/check_dump.yml
+++ b/tasks/debug/check_dump.yml
@@ -3,7 +3,15 @@
 - debug:
     msg: "{{ dumps.stdout_lines|join('\n') }}"
 
-- debug:
+- command: docker exec easydb-pgsql psql -U postgres -l
+  name: get list of dbs from postgres with psql -l
+  register: dblist
+- name: result of psql -l
+  debug:
+    msg: "{{ dblist.stdout_lines|join('\n') }}"
+
+- name: ansible configuration
+  debug:
     var: easydb_dump_dbs
 
 - command: grep '^DBS=' {{ easydb_basedir }}/maintain

--- a/tasks/debug/check_dump.yml
+++ b/tasks/debug/check_dump.yml
@@ -6,6 +6,7 @@
 - command: docker exec easydb-pgsql psql -U postgres -l
   name: get list of dbs from postgres with psql -l
   register: dblist
+  failed_when: no
 - name: result of psql -l
   debug:
     msg: "{{ dblist.stdout_lines|join('\n') }}"
@@ -20,5 +21,13 @@
 - name: result of grep
   debug:
     var: DBS.stdout_lines
+
+- shell: "wget -q 127.0.0.1:{{ easydb_webfrontend_port_ext }}/api/v1/settings -O - |grep db-name"
+  name: query /api/v1/settings for db-name
+  register: api
+  failed_when: no
+- name: result of api query
+  debug:
+    var: api.stdout_lines
 
 - meta: end_play

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,5 @@
 # to only run these checks: ansible-playbook -i inv*/$ID/hosts.ini plays/$ID/easydb5.pgsql.yml --extra-vars=debug_dump_only=true
+# note: role docker will still be executed
 - name: only check db dump
   when: 'debug_dump_only|default(false)'
   include_tasks: debug/check_dump.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,3 +1,8 @@
+# to only run these checks: ansible-playbook -i inv*/$ID/hosts.ini plays/$ID/easydb5.pgsql.yml --extra-vars=debug_dump_only=true
+- name: only check db dump
+  when: 'debug_dump_only|default(false)'
+  include_tasks: debug/check_dump.yml
+
 - name: include distro prep'er
   with_first_found:
     - prepare/{{ ansible_distribution }}.{{ ansible_lsb.codename }}.yml


### PR DESCRIPTION
Because of a wrong config on a production system (internal ticket #52894) we now have to check all sites for correct sql dumps. The changes here enable this with

  --extra-vars=debug_dump_only=true