### PR TITLE
Fix group names

### DIFF
--- a/tasks/prepare/checks.yml
+++ b/tasks/prepare/checks.yml
@@ -53,12 +53,7 @@
   fail:
     msg: "[easydb5_fylr_servers:children] is missing (e.g. in inventory/hosts.ini)"
 
-- name: Check that fylr is either fully configured or not at all 1
+- name: Check that fylr is either fully configured or not at all
   when: not (groups.easydb5_fylr_servers.0 is defined) and 'fylr' in easydb_containers_on_host[inventory_hostname]
   fail:
     msg: "easydb5_fylr_servers is empty BUT fylr is in easydb_containers_on_host"
-
-- name: Check that fylr is either fully configured or not at all 2
-  when: groups.easydb5_fylr_servers.0 is defined and 'fylr' not in easydb_containers_on_host[inventory_hostname]
-  fail:
-    msg: "easydb5_fylr_servers has entries BUT fylr is missing in easydb_containers_on_host"

--- a/tasks/prepare/checks.yml
+++ b/tasks/prepare/checks.yml
@@ -47,3 +47,18 @@
   when: easydb_objectstore_url != '' and easydb_datamodel_uid == ''
   fail:
     msg: Either set easydb_objectstore_url to empty string or set easydb_datamodel_uid!
+
+- name: Check that easydb5_fylr_servers is in inventory
+  when: not (groups.easydb5_fylr_servers is defined)
+  fail:
+    msg: "[easydb5_fylr_servers:children] is missing (e.g. in inventory/hosts.ini)"
+
+- name: Check that fylr is either fully configured or not at all 1
+  when: not (groups.easydb5_fylr_servers.0 is defined) and 'fylr' in easydb_containers_on_host[inventory_hostname]
+  fail:
+    msg: "easydb5_fylr_servers is empty BUT fylr is in easydb_containers_on_host"
+
+- name: Check that fylr is either fully configured or not at all 2
+  when: groups.easydb5_fylr_servers.0 is defined and 'fylr' not in easydb_containers_on_host[inventory_hostname]
+  fail:
+    msg: "easydb5_fylr_servers has entries BUT fylr is missing in easydb_containers_on_host"

--- a/templates/srv/easydb/config/elasticsearch.yml.j2
+++ b/templates/srv/easydb/config/elasticsearch.yml.j2
@@ -13,8 +13,8 @@ config:
 {% endif %}
 
   "node.name": "{{ inventory_hostname }}"
-  "node.master": "{% if 'easydb5-elasticsearch-masters' in group_names %}true{% else %}false{% endif %}"
-  "node.data": "{% if 'easydb5-elasticsearch-data' in group_names %}true{% else %}false{% endif %}"
+  "node.master": "{% if 'easydb5_elasticsearch_masters' in group_names %}true{% else %}false{% endif %}"
+  "node.data": "{% if 'easydb5_elasticsearch_data' in group_names %}true{% else %}false{% endif %}"
   "http.port": "{{ easydb_elasticsearch_cluster_port | default(easydb_elasticsearch_port_int) }}"
   "network.publish_host": "{{ easydb_elasticsearch_network_publish_host | default("") }}"
   "discovery.zen.ping.unicast.hosts": {{ easydb_elasticsearch_cluster_nodes | default([]) | to_json }}


### PR DESCRIPTION
groups names in inventory have been written with hyphens until now, like this: 
   easydb5-fylr-servers
... which brings problems ("easydb5 is not defined").

This branch replaces hyphens with underscores, which is less troublesome.

(https://docs.ansible.com/ansible/latest/network/getting_started/first_inventory.html#basic-inventory)