### PR TITLE
restricted the docker seccomp argument to easydb-server. see #56447

### DIFF
--- a/templates/srv/easydb/run-script.j2
+++ b/templates/srv/easydb/run-script.j2
@@ -3,7 +3,9 @@
 {{ ansible_managed | comment }}
 
 docker run -d -ti \
+{% if easydb_containers[easydb_container].container_name == 'easydb-server' %}
     --security-opt seccomp=unconfined \
+{% endif %}
     --name {{ easydb_containers[easydb_container].container_name }} \
     --restart=always \
     --net {{ easydb_container_network }} \

--- a/templates/srv/easydb/run-script.j2
+++ b/templates/srv/easydb/run-script.j2
@@ -3,7 +3,7 @@
 {{ ansible_managed | comment }}
 
 docker run -d -ti \
-{% if easydb_containers[easydb_container].container_name == 'easydb-server' %}
+{% if 'easydb-server' in easydb_containers[easydb_container].container_name %}
     --security-opt seccomp=unconfined \
 {% endif %}
     --name {{ easydb_containers[easydb_container].container_name }} \


### PR DESCRIPTION
This fix no longer sets the Docker Seccomp argument for all containers. In the future this option will be set just for the easydb-server container.