### PR TITLE
Ubuntu 20.04 Support: install docker3.python instead of docker.python

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,7 +6,7 @@
 
 - name: include distro prep'er
   with_first_found:
-    - prepare/{{ ansible_distribution }}.{{ ansible_lsb.codename }}.yml
+    - prepare/{{ ansible_distribution }}.{{ ansible_distribution_version }}.yml
     - prepare/{{ ansible_distribution }}.yml
     - prepare/default.yml
   loop_control:
@@ -15,7 +15,7 @@
 
 - name: include distro installer
   with_first_found:
-    - install/{{ ansible_distribution }}.{{ ansible_lsb.codename }}.yml
+    - install/{{ ansible_distribution }}.{{ ansible_distribution_version }}.yml
     - install/{{ ansible_distribution }}.yml
     - install/default.yml
   loop_control:
@@ -24,7 +24,7 @@
 
 - name: include distro configurator
   with_first_found:
-    - configure/{{ ansible_distribution }}.{{ ansible_lsb.codename }}.yml
+    - configure/{{ ansible_distribution }}.{{ ansible_distribution_version }}.yml
     - configure/{{ ansible_distribution }}.yml
     - configure/default.yml
   loop_control:

--- a/tasks/prepare/Ubuntu.20.04.yml
+++ b/tasks/prepare/Ubuntu.20.04.yml
@@ -1,0 +1,19 @@
+- include_tasks: checks.yml
+
+- name: configuring APT proxy
+  when: easydb_proxy_url
+  include_tasks: proxy.yml
+
+- name: installing Python docker bindings
+  apt:
+    pkg: python3-docker
+    state: present
+    update_cache: no
+    install_recommends: no
+
+- name: adjusting sysctl max-map-count
+  sysctl:
+    name: vm.max_map_count
+    value: "{{ easydb_max_map_count }}"
+    reload: yes
+


### PR DESCRIPTION
Bitte checken, noch nicht getestet.